### PR TITLE
Update Qt land

### DIFF
--- a/v1/places.geojson
+++ b/v1/places.geojson
@@ -3203,7 +3203,7 @@
       },
       "properties": {
         "symbolzoom": 8,
-        "name": "PyQTia",
+        "name": "Qtopia",
         "labelId": "brfeh",
         "ownerId": 1879
       }


### PR DESCRIPTION
The label includes the general Qt ecosystem, not just PyQt.
The `Qtopia` name is a throw-back to the old mobile OS by Trolltech:
https://en.wikipedia.org/wiki/Qt_Extended